### PR TITLE
Fix crash when device has no axis and fake two axis so proton is able to see the joystick

### DIFF
--- a/spoof-device.py
+++ b/spoof-device.py
@@ -31,8 +31,13 @@ print("Using:", device.name)
 
 caps = {
     ecodes.EV_MSC : [ecodes.MSC_SCAN],
-    ecodes.EV_ABS : device.capabilities()[ecodes.EV_ABS],
 }
+
+if ecodes.EV_ABS in device.capabilities():
+    caps[ecodes.EV_ABS] = device.capabilities()[ecodes.EV_ABS]
+else:
+    # Some devices do not have axis, so fake at least two axis
+    caps[ecodes.EV_ABS] = [ecodes.ABS_X, ecodes.ABS_Y]
 
 if ecodes.EV_KEY in device.capabilities():
     caps[ecodes.EV_KEY] = device.capabilities()[ecodes.EV_KEY]


### PR DESCRIPTION
I bought the "Thrustmaster MFD" a kinda Joystick with 28 buttons and no axis. To be properly recognized as a joystick by steams proton it has to have at least X and Y axis. So now by default if a device lacks axis it adds a dummy x and y axis.